### PR TITLE
feat: add AdsBilled metric support

### DIFF
--- a/config/config.json.example
+++ b/config/config.json.example
@@ -18,6 +18,7 @@
     "AdDecisionServer.Errors",
     "AdDecisionServer.Timeouts",
     "Avail.Impression",
+    "AdsBilled",
     "Avail.ObservedDuration",
     "Avail.ObservedFilledDuration",
     "GetManifest.Errors",

--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -762,9 +762,10 @@ def generate_pdf_config_section(config_name: str, metrics: Dict, styles, overall
             ]
         },
         'Volume & Impression Metrics': {
-            'description': 'Informational metrics showing ad impression counts and total ad volume.',
+            'description': 'Informational metrics showing ad impression counts, ads billed, and total ad volume.',
             'metrics': [
-                'Avail.Impression'
+                'Avail.Impression',
+                'AdsBilled'
             ]
         }
     }
@@ -776,7 +777,7 @@ def generate_pdf_config_section(config_name: str, metrics: Dict, styles, overall
     RATE_METRICS = ['Avail.FillRate', 'AdDecisionServer.FillRate', 'Avail.ObservedFillRate']
     DURATION_METRICS = ['Avail.Duration', 'Avail.FilledDuration', 'Avail.ObservedDuration', 'Avail.ObservedFilledDuration', 'AdDecisionServer.Duration']
     LATENCY_METRICS = ['AdDecisionServer.Latency', 'GetManifest.Latency']
-    COUNT_METRICS = ['AdDecisionServer.Ads', 'AdDecisionServer.Errors', 'AdDecisionServer.Timeouts', 'Avail.Impression', 'GetManifest.Errors', 'Origin.Errors', 'Origin.Timeouts']
+    COUNT_METRICS = ['AdDecisionServer.Ads', 'AdDecisionServer.Errors', 'AdDecisionServer.Timeouts', 'Avail.Impression', 'AdsBilled', 'GetManifest.Errors', 'Origin.Errors', 'Origin.Timeouts']
     
     # Generate tables for each metric group (only show groups with metrics present)
     for group_name, group_config in metric_groups.items():
@@ -864,7 +865,7 @@ def generate_pdf_config_section(config_name: str, metrics: Dict, styles, overall
                 elif rate_percent < 80:
                     status_text = "🟡 Warning"
                 # else: ✓ Healthy (default)
-            elif metric in DURATION_METRICS or metric == 'Avail.Impression':
+            elif metric in DURATION_METRICS or metric in ['Avail.Impression', 'AdsBilled']:
                 # Duration and volume metrics are informational only
                 if sum_val == 0:
                     status_text = "⚪ No Data"


### PR DESCRIPTION
## Summary
- Adds support for the `AdsBilled` CloudWatch metric from the `AWS/MediaTailor` namespace
- `AdsBilled` tracks the number of ads for which MediaTailor bills customers based on insertion
- Classified as an informational volume metric (ℹ️ Info status, no alerting thresholds)
- Added to the "Volume & Impression Metrics" group alongside `Avail.Impression`

## Changes
- `lambda/lambda_function.py`: Added `AdsBilled` to metric group, COUNT_METRICS list, and informational status logic
- `config/config.json.example`: Added `AdsBilled` to example config

## Usage
Customers add `"AdsBilled"` to their `config.json` metrics array:
```json
"metrics": ["AdsBilled", "Avail.Impression"]
```

## Test plan
- [ ] Deploy stack and verify `AdsBilled` metric is fetched from CloudWatch
- [ ] Confirm PDF report shows `AdsBilled` under "Volume & Impression Metrics" group
- [ ] Verify status displays as "ℹ️ Info" when data is present and "⚪ No Data" when absent
- [ ] Confirm no regression in existing metrics